### PR TITLE
Remove tune.ssl.default-dh-param directive

### DIFF
--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -7,7 +7,6 @@ global
 	# https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4.2-log%20global
 	log stdout format raw daemon            # send everything to stdout
 	log stderr format raw daemon notice     # send important events to stderr
-	tune.ssl.default-dh-param 2048
 	{{ with .SSLCiphers }}
 	ssl-default-bind-ciphers {{ . }}
 	{{ else }}


### PR DESCRIPTION
## Summary
- Remove `tune.ssl.default-dh-param` from global config; unsupported by AWS-LC 1.69.0 and unnecessary for modern ECDHE-based TLS